### PR TITLE
Add Pydantic schemas for summaries

### DIFF
--- a/backend/app/schemas/summary_schemas.py
+++ b/backend/app/schemas/summary_schemas.py
@@ -1,0 +1,26 @@
+"""Schemas for summary resources."""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+from pydantic import ConfigDict
+
+
+class SummaryIn(BaseModel):
+    title: str = Field(min_length=1)
+    content: str = Field(min_length=1)
+    document_id: int
+
+
+class SummaryOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    title: str
+    content: str
+    document_id: int
+    created_at: Optional[datetime] = None
+
+
+class SummaryListOut(BaseModel):
+    items: List[SummaryOut]


### PR DESCRIPTION
## Summary
- add Pydantic models for summary creation, retrieval, and list responses
- include from_attributes configuration for ORM compatibility and optional created_at field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e69e6e15108331b1531def54518458