### PR TITLE
Include summaries router in FastAPI app

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.routers.health import router as health_router
 from app.routers.documents import router as documents_router
 from app.routers.auth import router as auth_router  # ← nuevo
+from app.routers.summaries import router as summaries_router
 
 app = FastAPI(title="StudyForge API")
 
@@ -27,3 +28,4 @@ app.add_middleware(
 app.include_router(health_router, prefix="/health", tags=["health"])
 app.include_router(auth_router)  # el router ya define prefix="/auth" y tags=["auth"]
 app.include_router(documents_router, prefix="/documents", tags=["documents"])
+app.include_router(summaries_router, prefix="/summaries", tags=["summaries"])


### PR DESCRIPTION
## Summary
- import the summaries router into the FastAPI application
- register the summaries routes with a /summaries prefix and tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6a26099908331897bbb6a76302a79